### PR TITLE
added no auto commands ( noa ) before write

### DIFF
--- a/lua/autosave/main.lua
+++ b/lua/autosave/main.lua
@@ -3,6 +3,7 @@ local cmd = vim.cmd
 local opts = require("autosave.config").options
 local autocmds = require("autosave.modules.autocmds")
 local autosave = require("autosave")
+local status_autosave
 
 require("autosave.utils.viml_funcs")
 

--- a/lua/autosave/modules/autocmds.lua
+++ b/lua/autosave/modules/autocmds.lua
@@ -36,9 +36,9 @@ local function actual_save()
 		local last_char_pos = fn.getpos("']")
 
 		if opts["write_all_buffers"] then
-			cmd("silent! wall")
+			cmd("silent! noa wall")
 		else
-			cmd("silent! write")
+			cmd("silent! noa write")
 		end
 
 		fn.setpos("'[", first_char_pos)


### PR DESCRIPTION
im using `trim.nvim` and i guess many people are using too. that plugin just trims trailing white space after buffer save, it has an autocmd attached.

when using both plugins at the same time, you cant write in insert mode because while you are writing the whitespace (space between the last word and current word) will be deleted.

so i added this minor change and made a PR.

its working, i've tested.

im making a PR into 'dev' branch to make sure nothing will break and to not destroy `main` branch. if its working, then you will merge on your own.

peace!

