### PR TITLE
added hook_before_actual_saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,14 +248,15 @@ These are the conditions that every file must meet so that it can be saved. If e
 ## Hooks
 Use them to execute code at certain events [described by their names]. These are the ones available:
 
-| Function             | Description                                                        |
-|----------------------|--------------------------------------------------------------------|
-| hook_before_on()     | Before toggling the plugin on                                      |
-| hook_after_on()      | After toggling the plugin on                                       |
-| hook_before_off()    | Before toggling the plugin off                                     |
-| hook_after_off()     | After toggling the plugin off                                      |
-| hook_before_saving() | Before its even checked if the current file(s) meet the conditions |
-| hook_after_saving    | After saving the file(s)                                           |
+| Function                    | Description                                                        |
+|-----------------------------|--------------------------------------------------------------------|
+| hook_before_on()            | Before toggling the plugin on                                      |
+| hook_after_on()             | After toggling the plugin on                                       |
+| hook_before_off()           | Before toggling the plugin off                                     |
+| hook_after_off()            | After toggling the plugin off                                      |
+| hook_before_saving()        | Before its even checked if the current file(s) meet the conditions |
+| hook_after_saving()         | After saving the file(s)                                           |
+| hook_before_actual_saving() | Before actual saving (after `debounce_delay`)                      |
 
 They can be used like so:
 
@@ -267,7 +268,7 @@ autosave.hook_after_off = function ()
 end
 ```
 
-The `hook_before_saving` hook can be used to abort saving based on some condition:
+The `hook_before_saving`/`hook_before_actual_saving` hooks can be used to abort saving based on some condition:
 
 ```lua
 local autosave = require("autosave")

--- a/doc/autosave.txt
+++ b/doc/autosave.txt
@@ -170,14 +170,15 @@ These are the conditions that every file must meet so that it can be saved. If e
 ## Hooks
 Use them to execute code at certain events [described by their names]. These are the ones available:
 
-| Function             | Description                                                          |
-|----------------------|----------------------------------------------------------------------|
-| hook_before_on()     | Before toggling the plugin on                                        |
-| hook_after_on()      | After toggling the plugin on                                         |
-| hook_before_off()    | Before toggling the plugin off                                       |
-| hook_after_off()     | After toggling the plugin off                                        |
-| hook_before_saving() | Before its even checked if the file meets the conditions to be saved |
-| hook_after_saving    | After successfully saving the file or not                            |
+| Function                    | Description                                                        |
+|-----------------------------|--------------------------------------------------------------------|
+| hook_before_on()            | Before toggling the plugin on                                      |
+| hook_after_on()             | After toggling the plugin on                                       |
+| hook_before_off()           | Before toggling the plugin off                                     |
+| hook_after_off()            | After toggling the plugin off                                      |
+| hook_before_saving()        | Before its even checked if the current file(s) meet the conditions |
+| hook_after_saving()         | After saving the file(s)                                           |
+| hook_before_actual_saving() | Before actual saving (after `debounce_delay`)                      |
 
 They can be used like so:
 
@@ -189,7 +190,7 @@ autosave.hook_after_off = function ()
 end
 ```
 
-The `hook_before_saving` hook can be used to abort saving based on some condition:
+The `hook_before_saving`/`hook_before_actual_saving` hooks can be used to abort saving based on some condition:
 
 ```lua
 local autosave = require("autosave")

--- a/lua/autosave/main.lua
+++ b/lua/autosave/main.lua
@@ -3,6 +3,7 @@ local cmd = vim.cmd
 local opts = require("autosave.config").options
 local autocmds = require("autosave.modules.autocmds")
 local autosave = require("autosave")
+local status_autosave
 
 require("autosave.utils.viml_funcs")
 

--- a/lua/autosave/modules/autocmds.lua
+++ b/lua/autosave/modules/autocmds.lua
@@ -32,6 +32,14 @@ local function actual_save()
 	-- might use  update, but in that case it can't be checked if a file was modified and so it will always
 	-- print opts["execution_message"]
 	if api.nvim_eval([[&modified]]) == 1 then
+		if autosave.hook_before_actual_saving ~= nil then
+			autosave.hook_before_actual_saving()
+		end
+
+		if vim.g.auto_save_abort then
+			return
+		end
+
 		local first_char_pos = fn.getpos("'[")
 		local last_char_pos = fn.getpos("']")
 

--- a/lua/autosave/modules/autocmds.lua
+++ b/lua/autosave/modules/autocmds.lua
@@ -4,199 +4,182 @@ local cmd = vim.cmd
 
 local opts = require("autosave.config").options
 local autosave = require("autosave")
-local default_events = {"InsertLeave", "TextChanged"}
+local default_events = { "InsertLeave", "TextChanged" }
 
 local modified
 
 local M = {}
 
 local function table_has_value(tbl, value)
-    for key, _ in pairs(tbl) do
-        if (tbl[key] == value) then
-            return true
-        end
-    end
+	for key, _ in pairs(tbl) do
+		if tbl[key] == value then
+			return true
+		end
+	end
 
-    return false
+	return false
 end
 
 local function set_modified(value)
-    modified = value
+	modified = value
 end
 
 local function get_modified()
-    return modified
+	return modified
 end
 
 local function actual_save()
-    -- might use  update, but in that case it can't be checked if a file was modified and so it will always
-    -- print opts["execution_message"]
-    if (api.nvim_eval([[&modified]]) == 1) then
-        local first_char_pos = fn.getpos("'[")
-        local last_char_pos = fn.getpos("']")
+	-- might use  update, but in that case it can't be checked if a file was modified and so it will always
+	-- print opts["execution_message"]
+	if api.nvim_eval([[&modified]]) == 1 then
+		local first_char_pos = fn.getpos("'[")
+		local last_char_pos = fn.getpos("']")
 
-        cmd("silent! write")
+		if opts["write_all_buffers"] then
+			cmd("silent! wall")
+		else
+			cmd("silent! write")
+		end
 
-        fn.setpos("'[", first_char_pos)
-        fn.setpos("']", last_char_pos)
+		fn.setpos("'[", first_char_pos)
+		fn.setpos("']", last_char_pos)
 
-        if (get_modified() == nil or get_modified() == false) then
-            set_modified(true)
-        end
+		if get_modified() == nil or get_modified() == false then
+			set_modified(true)
+		end
 
-        M.message_and_interval()
-    end
+		M.message_and_interval()
+	end
 end
 
 local function assert_user_conditions()
-    local sc_exists, sc_filetype, sc_modifiable = true, true, true
+	local sc_exists, sc_filetype, sc_modifiable = true, true, true
 
-    for condition, value in pairs(opts["conditions"]) do
-        if (condition == "exists") then
-            if (value == true) then
-                if (fn.filereadable(fn.expand("%:p")) == 0) then
-                    sc_exists = false
-                    break
-                end
-            end
-        elseif (condition == "modifiable") then
-            if (value == true) then
-                if (api.nvim_eval([[&modifiable]]) == 0) then
-                    sc_modifiable = false
-                    break
-                end
-            end
-        elseif (condition == "filetype_is_not") then
-            if not (next(opts["conditions"]["filetype_is_not"]) == nil) then
-                if (table_has_value(opts["conditions"]["filetype_is_not"], api.nvim_eval([[&filetype]])) == true) then
-                    sc_filetype = false
-                    break
-                end
-            end
-        end
-    end
+	for condition, value in pairs(opts["conditions"]) do
+		if condition == "exists" then
+			if value == true then
+				if fn.filereadable(fn.expand("%:p")) == 0 then
+					sc_exists = false
+					break
+				end
+			end
+		elseif condition == "modifiable" then
+			if value == true then
+				if api.nvim_eval([[&modifiable]]) == 0 then
+					sc_modifiable = false
+					break
+				end
+			end
+		elseif condition == "filetype_is_not" then
+			if not (next(opts["conditions"]["filetype_is_not"]) == nil) then
+				if table_has_value(opts["conditions"]["filetype_is_not"], api.nvim_eval([[&filetype]])) == true then
+					sc_filetype = false
+					break
+				end
+			end
+		end
+	end
 
-    return {sc_exists, sc_filetype, sc_modifiable}
+	return { sc_exists, sc_filetype, sc_modifiable }
 end
 
 local function assert_return(values, expected)
-    for key, value in pairs(values) do
-        if (value ~= expected) then
-            return false
-        end
-    end
+	for key, value in pairs(values) do
+		if value ~= expected then
+			return false
+		end
+	end
 
-    return true
+	return true
 end
 
 function M.message_and_interval()
-    if (get_modified() == true) then
-        set_modified(false)
-        if (opts["execution_message"] ~= "") then
-            print(opts["execution_message"])
-        end
+	if get_modified() == true then
+		set_modified(false)
+		if opts["execution_message"] ~= "" then
+			print(opts["execution_message"])
+		end
 
-        if (opts["clean_command_line_interval"] > 0) then
-            cmd(
-                [[call timer_start(]] ..
-                    opts["clean_command_line_interval"] .. [[, funcref('g:AutoSaveClearCommandLine'))]]
-            )
-        end
-    end
+		if opts["clean_command_line_interval"] > 0 then
+			cmd(
+				[[call timer_start(]]
+					.. opts["clean_command_line_interval"]
+					.. [[, funcref('g:AutoSaveClearCommandLine'))]]
+			)
+		end
+	end
 end
 
 local function debounce(lfn, duration)
-  local queued = false
+	local queued = false
 
-  local function inner_debounce()
-    if not queued then
-      vim.defer_fn(
-        function()
-          queued = false
-          lfn()
-        end,
-        duration
-      )
-      queued = true
-    end
-  end
+	local function inner_debounce()
+		if not queued then
+			vim.defer_fn(function()
+				queued = false
+				lfn()
+			end, duration)
+			queued = true
+		end
+	end
 
-  return inner_debounce
+	return inner_debounce
 end
 
 function M.do_save()
-    if (assert_return(assert_user_conditions(), true)) then
-        M.debounced_save()
-    end
+	if assert_return(assert_user_conditions(), true) then
+		M.debounced_save()
+	end
 end
 
 function M.save()
-    if (autosave.hook_before_saving ~= nil) then
-        autosave.hook_before_saving()
-    end
+	if autosave.hook_before_saving ~= nil then
+		autosave.hook_before_saving()
+	end
 
-    M.do_save()
+	M.do_save()
 
-    if (autosave.hook_after_saving ~= nil) then
-        autosave.hook_after_saving()
-    end
+	if autosave.hook_after_saving ~= nil then
+		autosave.hook_after_saving()
+	end
 end
 
-local function events()
-  if (next(opts["events"]) == nil or opts["events"] == nil) then
-    return default_events
-  else
-    return opts["events"]
-  end
+local function get_events()
+	if next(opts["events"]) == nil or opts["events"] == nil then
+		return default_events
+	else
+		return opts["events"]
+	end
 end
 
 local function parse_events()
-  return table.concat(events(), ",")
+	return table.concat(get_events(), ",")
 end
 
 function M.load_autocommands()
-    if opts["debounce_delay"] == 0 then
-        M.debounced_save = actual_save
-    else
-        M.debounced_save = debounce(actual_save, opts["debounce_delay"])
-    end
+	if opts["debounce_delay"] == 0 then
+		M.debounced_save = actual_save
+	else
+		M.debounced_save = debounce(actual_save, opts["debounce_delay"])
+	end
 
-    if (opts["write_all_buffers"] == false) then
-        api.nvim_exec(
-            [[
-			aug autosave_save
-				au!
-				au ]] ..
-                parse_events() ..
-                    [[ * execute "lua require'autosave.modules.autocmds'.save()"
-			aug END
-		]],
-            false
-        )
-    else
-        local event_1 = events()[1]
-        api.nvim_exec(
-            [[
-			aug autosave_save
-				au!
-				au ]] ..
-                parse_events() ..
-                    [[ * if !exists("g:autosave_changed") | let g:autosave_changed="t" | doautoall autosave_save ]] ..
-                        event_1 ..
-                            [[ | unlet g:autosave_changed | else | execute "lua require'autosave.modules.autocmds'.save()" | endif
-			aug END
-		]],
-            false
-        )
-    end
+	api.nvim_exec([[
+		aug autosave_save
+			au!
+			au ]] .. parse_events() .. [[ * execute "lua require'autosave.modules.autocmds'.save()"
+		aug END
+	]], false)
 end
 
 function M.unload_autocommands()
-    api.nvim_exec([[
+	api.nvim_exec(
+		[[
 		aug autosave_save
 			au!
 		aug END
-	]], false)
+	]],
+		false
+	)
 end
 
 return M


### PR DESCRIPTION
[nvim-autopairs](https://github.com/windwp/nvim-autopairs) is triggering the `TextChanged` autocmd when it inserts new pair, it does it by go to normal mode change stuff and go back to insert mode, `AutoSave.nvim` triggers and autosave that might be unwanted.

I tried to avoid it by check if I'm in insert mode before save but I realized it does the check before the `debounce` when the mode is still normal.

I had to check if i'm in insert mode before the actual saving so I added `hook_before_actual_saving` and added this hook to my conf:
```lua
autosave.hook_before_actual_saving = function ()
	mode = vim.api.nvim_get_mode()
	if mode.mode == 'i' then -- Don't save while we in insert mode (triggered with autopair and such)
		vim.g.auto_save_abort = true
	end
end
```