### PR TITLE
Add Disclaimer about name change to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 
 &nbsp;
 
+### 📢 Disclaimer: Breaking Change
+
+This plugin has been renamed from `AutoSave` to `auto-save`, and this repository has accordingly moved from `pocco81/AutoSave.nvim` to `pocco81/auto-save.nvim`. To prevent errors with your configuration, make sure to update both the name and the repository url in your config! 
+
 ### 📋 Features
 
 - automatically save your changes so the world doesn't collapse

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 This plugin has been renamed from `AutoSave` to `auto-save`, and this repository has accordingly moved from `pocco81/AutoSave.nvim` to `pocco81/auto-save.nvim`. To prevent errors with your configuration, make sure to update both the name and the repository url in your config! 
 
+&nbsp;
+
 ### 📋 Features
 
 - automatically save your changes so the world doesn't collapse


### PR DESCRIPTION
This was a non-obvious source of pretty annoying errors with `packer.nvim` for me. I'm probably not the only one.