### PR TITLE
Fix error in colors.lua on startup

### DIFF
--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -107,12 +107,13 @@ function M.on()
 		callback = function()
 			vim.schedule(function()
 				if cnf.opts.execution_message.dim > 0 then
-					MSG_AREA = colors.get_hl("MsgArea")
+					MSG_AREA = colors.get_hl(AUTO_SAVE_COLOR)
+					MSG_AREA.foreground = (MSG_AREA.foreground or colors.get_hl("Normal")["foreground"])
 					MSG_AREA.background = (MSG_AREA.background or colors.get_hl("Normal")["background"])
 					local foreground = (
 						o.background == "dark" and
-							colors.darken((MSG_AREA.background or "#000000"), cnf.opts.execution_message.dim, MSG_AREA.foreground) or
-							colors.lighten((MSG_AREA.background or "#ffffff"), cnf.opts.execution_message.dim, MSG_AREA.foreground)
+							colors.darken((MSG_AREA.background or "#000000"), cnf.opts.execution_message.dim, (MSG_AREA.foreground or "#ffffff")) or
+							colors.lighten((MSG_AREA.background or "#ffffff"), cnf.opts.execution_message.dim, (MSG_AREA.foreground or "#000000"))
 						)
 
 					colors.highlight("AutoSaveText", { fg = foreground })

--- a/lua/auto-save/utils/colors.lua
+++ b/lua/auto-save/utils/colors.lua
@@ -60,11 +60,13 @@ function M.blend(fg, bg, alpha)
 end
 
 function M.darken(hex, amount, bg)
-	return M.blend(hex, bg or M.bg, math.abs(amount))
+        bg = bg or "#000000"
+	return M.blend(hex, bg, math.abs(amount))
 end
 
 function M.lighten(hex, amount, fg)
-	return M.blend(hex, fg or M.fg, math.abs(amount))
+        fg = fg or "#ffffff"
+	return M.blend(hex, fg, math.abs(amount))
 end
 
 return M


### PR DESCRIPTION
Closes https://github.com/Pocco81/auto-save.nvim/issues/34

There seems to be no such thing as `M.fg` nor `M.bg` resulting in a `nil` value.
Also `MsgArea` is does not always have foreground/background set and I guess also `Normal` may not have them.

**NB I got slightly confused which way the `lighten`/`darken` function works (as currently `foreground` seems to be passed in for `bg`) so please tell me if I did something stupid here** :stuck_out_tongue: 

