### PR TITLE
Fix to not try to save a deleted buffer

### DIFF
--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -41,8 +41,10 @@ local function debounce(lfn, duration)
         local buf = api.nvim_get_current_buf()
 		if not get_buf_var(buf, 'queued') then
 			vim.defer_fn(function()
-                set_buf_var(buf, 'queued', false)
-				lfn(buf)
+                if api.nvim_buf_is_valid(buf) then
+                    set_buf_var(buf, 'queued', false)
+                    lfn(buf)
+                end
 			end, duration)
             set_buf_var(buf, 'queued', true)
 		end


### PR DESCRIPTION
Sometimes the buffer can be deleted before being saved, like the input
dialog the NvimTree creates when renaming or creating a file

Add a check in debounce to verify if the buffer is still valid before
trying to save

Minimal configuration to reproduce the error

```
local execute = vim.api.nvim_command
local fn = vim.fn

local install_path = fn.stdpath('data') .. '/site/minimal_pack/minimal_packer/start/packer.nvim'

if fn.empty(fn.glob(install_path)) > 0 then
  fn.system({ 'git', 'clone', 'https://github.com/wbthomason/packer.nvim', install_path })
  execute 'packadd packer.nvim'
end

return require("packer").startup {
  function(use)
    use { 'wbthomason/packer.nvim' }

    use {
      'kyazdani42/nvim-tree.lua',
      requires = { 'kyazdani42/nvim-web-devicons'},
      config = function()
        require 'nvim-tree'.setup {
          disable_netrw = false,
          hijack_netrw  = true,
        }
      end
    }

    use { "Pocco81/auto-save.nvim" }
  end
}
```

Steps:

1 - Open NvimTree ( e.g. using `:NvimTreeToggle` )
2 - Press `a`to open the dialog to create a new file
3 -After saving the error:

```
Error executing vim.schedule lua callback: ...nimal-packer/start/auto-save.nvim/lua/auto-save/init.lua:27: Invalid buffer id: 4
stack traceback:
        [C]: in function 'nvim_buf_set_var'
        ...nimal-packer/start/auto-save.nvim/lua/auto-save/init.lua:27: in function 'set_buf_var'
        ...nimal-packer/start/auto-save.nvim/lua/auto-save/init.lua:44: in function ''
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

