### PR TITLE
Fix empty message echoing

### DIFF
--- a/lua/auto-save/init.lua
+++ b/lua/auto-save/init.lua
@@ -78,14 +78,16 @@ function M.save(buf)
 
 	callback("after_saving")
 
-	api.nvim_echo({ { (type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message() or cnf.opts.execution_message.message), AUTO_SAVE_COLOR } }, true, {})
-	if cnf.opts.execution_message.cleaning_interval > 0 then
-		fn.timer_start(
-			cnf.opts.execution_message.cleaning_interval,
-			function()
-				cmd([[echon '']])
-			end
-		)
+	if cnf.opts.execution_message.message ~= '' then
+		api.nvim_echo({ { (type(cnf.opts.execution_message.message) == "function" and cnf.opts.execution_message.message() or cnf.opts.execution_message.message), AUTO_SAVE_COLOR } }, true, {})
+		if cnf.opts.execution_message.cleaning_interval > 0 then
+			fn.timer_start(
+				cnf.opts.execution_message.cleaning_interval,
+				function()
+					cmd([[echon '']])
+				end
+			)
+		end
 	end
 end
 


### PR DESCRIPTION
Should not `echo` or `clean` the command line when message is disabled
For reference:
https://github.com/Pocco81/auto-save.nvim/blob/e68e2c3e23ead1e007aad07186bb0e10da690eeb/lua/autosave/modules/autocmds.lua#L106